### PR TITLE
Bugfix/object font too dark

### DIFF
--- a/style.puml
+++ b/style.puml
@@ -241,7 +241,6 @@ skinparam object {
   arrow_style()
 
   attributeFontColor $SECONDARY
-  attributeFontName $FONTNAME
   attributeFontSize $FONTSIZE
 }
 

--- a/style.puml
+++ b/style.puml
@@ -239,6 +239,10 @@ skinparam object {
   basic_style()
   font_style()
   arrow_style()
+
+  attributeFontColor $SECONDARY
+  attributeFontName $FONTNAME
+  attributeFontSize $FONTSIZE
 }
 
 ' Common


### PR DESCRIPTION
Hey Drakemor,

the object diagrams use a black font also for the 
dark themes which makes them hard to read.

I configured objects similar to the class diagrams which fixes the issue.
Thanks a lot for the style. Very helpful for me.

Cheers,
Alex